### PR TITLE
fix: preserve hero image aspect ratio

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,8 @@ h2{font-size:32px;margin:0 0 10px}
 }
 
 .ui-demo{
-  width:100%;
+  max-width:100%;
+  height:auto;
   border-radius:12px;
   box-shadow:0 6px 28px rgba(0,0,0,.35);
   display:block;


### PR DESCRIPTION
## Summary
- ensure demo UI image retains original proportions with `max-width` and `height:auto`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f951f44883339cfa3e271a4e5f26